### PR TITLE
Add read_minutes assign

### DIFF
--- a/lib/dhony_web/live/blog_live/index.html.heex
+++ b/lib/dhony_web/live/blog_live/index.html.heex
@@ -20,5 +20,6 @@
     title={article.title}
     date={article.date}
     description={article.description}
+    read_minutes={article.read_minutes}
   />
 </div>


### PR DESCRIPTION
It was missing the `read_minutes` on the blog_live index `blog_preview_card` component.