### PR TITLE
Update check_origin to allow both www and non-www domains

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -21,4 +21,7 @@ config :logger, level: :info
 
 config :dhony, WebsiteWeb.Endpoint,
   url: [host: "www.dhony.dev", port: 443, scheme: "https"],
-  check_origin: true
+  check_origin: [
+    "https://www.dhony.dev",
+    "https://dhony.dev"
+  ]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -22,6 +22,6 @@ config :logger, level: :info
 config :dhony, WebsiteWeb.Endpoint,
   url: [host: "www.dhony.dev", port: 443, scheme: "https"],
   check_origin: [
-    "https://www.dhony.dev",
-    "https://dhony.dev"
+    "//www.dhony.dev",
+    "//dhony.dev"
   ]


### PR DESCRIPTION
This pull request updates the production configuration to improve security by specifying allowed origins for requests to the web endpoint.

Security and configuration improvements:

* [`config/prod.exs`](diffhunk://#diff-8e72c709985cb6a43cc0ab32cb487b8c17d2b2d003338ea42a4e2ad2829979dcL24-R27): The `check_origin` setting for `WebsiteWeb.Endpoint` is updated to explicitly allow only requests from `https://www.dhony.dev` and `https://dhony.dev`, instead of allowing all origins.